### PR TITLE
Fix Sentry OpenTelemetry severity correlation

### DIFF
--- a/bookapp/Cargo.toml
+++ b/bookapp/Cargo.toml
@@ -58,3 +58,6 @@ rand = "0.9.1"
 matchit = "^0.8"
 console-subscriber = "0.4.1"
 async-trait = "0.1.87"
+
+[dev-dependencies]
+sentry = { version = "0.41", features = ["test"] }

--- a/bookapp/src/book_ingestion.rs
+++ b/bookapp/src/book_ingestion.rs
@@ -121,7 +121,7 @@ pub async fn send_book_ingestion_message(
     });
 
     // Create Kafka record with headers
-    let key = format!("key-{}", &book_message.book_id.to_string());
+    let key = format!("key-{}", book_message.book_id);
     let record = FutureRecord::to("book_ingestion")
         .key(&key)
         .payload(&payload)

--- a/bookapp/src/sentry_correlation.rs
+++ b/bookapp/src/sentry_correlation.rs
@@ -10,7 +10,7 @@
 //! events in Sentry with the corresponding distributed traces in OpenTelemetry-compatible
 //! systems (like Grafana/Tempo). This layer bridges that gap by:
 //!
-//! 1. Intercepting ERROR-level tracing events
+//! 1. Intercepting WARN and ERROR-level tracing events
 //! 2. Extracting OpenTelemetry trace context from the current span
 //! 3. Adding `otel.trace_id` and `otel.span_id` tags to the Sentry scope
 //!
@@ -57,7 +57,7 @@ use tracing_subscriber::Layer;
 ///
 /// The layer implements the `tracing_subscriber::Layer` trait and processes events by:
 ///
-/// 1. Filtering for WARNING and ERROR-level events (configurable)
+/// 1. Filtering for WARNING and ERROR-level events
 /// 2. Extracting OpenTelemetry context from the event's span
 /// 3. Adding correlation tags to the Sentry scope
 ///
@@ -91,7 +91,6 @@ impl SentryOtelCorrelationLayer {
     /// Creates a new correlation layer with default settings.
     ///
     /// By default, WARNING and ERROR-level events trigger correlation.
-    /// Use `with_level()` to customize this behavior.
     pub fn new() -> Self {
         Self {
             min_level: tracing::Level::WARN,
@@ -200,6 +199,27 @@ mod tests {
         assert!(!layer.should_correlate(&Level::INFO));
         assert!(!layer.should_correlate(&Level::DEBUG));
         assert!(!layer.should_correlate(&Level::TRACE));
+    }
+
+    #[test]
+    fn event_without_an_active_span_does_not_add_correlation_tags() {
+        let subscriber = tracing_subscriber::registry().with(SentryOtelCorrelationLayer::new());
+        let events = sentry::test::with_captured_events(|| {
+            sentry::configure_scope(|scope| {
+                scope.remove_tag("otel.trace_id");
+                scope.remove_tag("otel.span_id");
+            });
+
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::warn!("event without an active span");
+            });
+            sentry::capture_message("captured without span context", sentry::Level::Warning);
+        });
+
+        let event = events.first().expect("one captured Sentry event");
+        assert_eq!(events.len(), 1);
+        assert!(!event.tags.contains_key("otel.trace_id"));
+        assert!(!event.tags.contains_key("otel.span_id"));
     }
 
     #[test]

--- a/bookapp/src/sentry_correlation.rs
+++ b/bookapp/src/sentry_correlation.rs
@@ -120,23 +120,22 @@ impl SentryOtelCorrelationLayer {
     ) where
         S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
     {
-        // Try to get OpenTelemetry context from the event's span
-        if let Some(span_ref) = ctx.event_span(event) {
-            // Get OpenTelemetry extensions from the span
-            if let Some(otel_data) = span_ref
-                .extensions()
-                .get::<tracing_opentelemetry::OtelData>()
-            {
-                if let (Some(trace_id), Some(span_id)) = (otel_data.trace_id(), otel_data.span_id())
-                {
-                    // Add OpenTelemetry context to Sentry scope for cross-platform correlation
-                    sentry::configure_scope(|scope| {
-                        scope.set_tag("otel.trace_id", format!("{trace_id:032x}"));
-                        scope.set_tag("otel.span_id", format!("{span_id:016x}"));
-                    });
-                }
+        let otel_ids = ctx.event_span(event).and_then(|span_ref| {
+            let extensions = span_ref.extensions();
+            let otel_data = extensions.get::<tracing_opentelemetry::OtelData>()?;
+            Some((otel_data.trace_id()?, otel_data.span_id()?))
+        });
+
+        sentry::configure_scope(|scope| match otel_ids {
+            Some((trace_id, span_id)) => {
+                scope.set_tag("otel.trace_id", format!("{trace_id:032x}"));
+                scope.set_tag("otel.span_id", format!("{span_id:016x}"));
             }
-        }
+            None => {
+                scope.remove_tag("otel.trace_id");
+                scope.remove_tag("otel.span_id");
+            }
+        });
     }
 }
 
@@ -162,7 +161,7 @@ where
     /// - Graceful degradation: Missing OTel context doesn't cause errors
     /// - Minimal allocations: Only formats trace IDs when correlation succeeds
     fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
-        // Only process events at or above the configured level
+        // Only process events at or more severe than the configured level.
         if self.should_correlate(event.metadata().level()) {
             self.correlate_with_sentry(&ctx, event);
         }
@@ -202,18 +201,41 @@ mod tests {
     }
 
     #[test]
-    fn event_without_an_active_span_does_not_add_correlation_tags() {
+    fn event_without_an_active_span_clears_existing_correlation_tags() {
         let subscriber = tracing_subscriber::registry().with(SentryOtelCorrelationLayer::new());
         let events = sentry::test::with_captured_events(|| {
             sentry::configure_scope(|scope| {
-                scope.remove_tag("otel.trace_id");
-                scope.remove_tag("otel.span_id");
+                scope.set_tag("otel.trace_id", "stale-trace");
+                scope.set_tag("otel.span_id", "stale-span");
             });
 
             tracing::subscriber::with_default(subscriber, || {
                 tracing::warn!("event without an active span");
             });
             sentry::capture_message("captured without span context", sentry::Level::Warning);
+        });
+
+        let event = events.first().expect("one captured Sentry event");
+        assert_eq!(events.len(), 1);
+        assert!(!event.tags.contains_key("otel.trace_id"));
+        assert!(!event.tags.contains_key("otel.span_id"));
+    }
+
+    #[test]
+    fn event_without_otel_data_clears_existing_correlation_tags() {
+        let subscriber = tracing_subscriber::registry().with(SentryOtelCorrelationLayer::new());
+        let events = sentry::test::with_captured_events(|| {
+            sentry::configure_scope(|scope| {
+                scope.set_tag("otel.trace_id", "stale-trace");
+                scope.set_tag("otel.span_id", "stale-span");
+            });
+
+            tracing::subscriber::with_default(subscriber, || {
+                let span = tracing::info_span!("span-without-otel-data");
+                let _guard = span.enter();
+                tracing::error!("event without OTel data");
+            });
+            sentry::capture_message("captured after cleanup", sentry::Level::Error);
         });
 
         let event = events.first().expect("one captured Sentry event");

--- a/bookapp/src/sentry_correlation.rs
+++ b/bookapp/src/sentry_correlation.rs
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn nested_span_has_the_same_trace_but_a_different_span_id() {
+    fn error_event_uses_the_current_child_span_context() {
         let provider = SdkTracerProvider::builder().build();
         let subscriber = tracing_subscriber::registry()
             .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("correlation-test")))
@@ -237,8 +237,8 @@ mod tests {
                     "each span has its own span ID"
                 );
 
-                tracing::warn!("capture current child context");
-                sentry::capture_message("captured after warning", sentry::Level::Warning);
+                tracing::error!("capture current child context");
+                sentry::capture_message("captured after error", sentry::Level::Error);
 
                 expected_trace_id = Some(child_span_context.trace_id().to_string());
                 expected_span_id = Some(child_span_context.span_id().to_string());

--- a/bookapp/src/sentry_correlation.rs
+++ b/bookapp/src/sentry_correlation.rs
@@ -83,7 +83,7 @@ use tracing_subscriber::Layer;
 /// ```
 pub struct SentryOtelCorrelationLayer {
     /// The minimum tracing level that triggers correlation.
-    /// Defaults to ERROR to minimize performance impact.
+    /// Defaults to WARN, which includes WARN and ERROR events.
     min_level: tracing::Level,
 }
 
@@ -96,6 +96,12 @@ impl SentryOtelCorrelationLayer {
         Self {
             min_level: tracing::Level::WARN,
         }
+    }
+
+    fn should_correlate(&self, event_level: &tracing::Level) -> bool {
+        // `tracing::Level` is ordered from most to least severe:
+        // ERROR < WARN < INFO < DEBUG < TRACE.
+        event_level <= &self.min_level
     }
 
     /// Extracts OpenTelemetry trace context and adds it to Sentry scope.
@@ -158,7 +164,7 @@ where
     /// - Minimal allocations: Only formats trace IDs when correlation succeeds
     fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
         // Only process events at or above the configured level
-        if event.metadata().level() >= &self.min_level {
+        if self.should_correlate(event.metadata().level()) {
             self.correlate_with_sentry(&ctx, event);
         }
     }
@@ -167,7 +173,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opentelemetry::trace::{TraceContextExt, TracerProvider};
+    use opentelemetry_sdk::trace::SdkTracerProvider;
     use tracing::Level;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    use tracing_subscriber::layer::SubscriberExt;
 
     #[test]
     fn test_new_layer_defaults_to_warn_level() {
@@ -179,5 +189,98 @@ mod tests {
     fn test_default_implementation() {
         let layer = SentryOtelCorrelationLayer::default();
         assert_eq!(layer.min_level, Level::WARN);
+    }
+
+    #[test]
+    fn warn_threshold_includes_error_and_warn_only() {
+        let layer = SentryOtelCorrelationLayer::new();
+
+        assert!(layer.should_correlate(&Level::ERROR));
+        assert!(layer.should_correlate(&Level::WARN));
+        assert!(!layer.should_correlate(&Level::INFO));
+        assert!(!layer.should_correlate(&Level::DEBUG));
+        assert!(!layer.should_correlate(&Level::TRACE));
+    }
+
+    #[test]
+    fn nested_span_has_the_same_trace_but_a_different_span_id() {
+        let provider = SdkTracerProvider::builder().build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("correlation-test")))
+            .with(SentryOtelCorrelationLayer::new());
+
+        let mut expected_trace_id = None;
+        let mut expected_span_id = None;
+        let events = sentry::test::with_captured_events(|| {
+            tracing::subscriber::with_default(subscriber, || {
+                let parent = tracing::info_span!("parent");
+                let _parent_guard = parent.enter();
+                let parent_context = parent.context();
+
+                let child = tracing::info_span!("child");
+                let _child_guard = child.enter();
+                let child_context = child.context();
+
+                let parent_span = parent_context.span();
+                let parent_span_context = parent_span.span_context();
+                let child_span = child_context.span();
+                let child_span_context = child_span.span_context();
+
+                assert_eq!(
+                    parent_span_context.trace_id(),
+                    child_span_context.trace_id(),
+                    "a child and its parent belong to the same trace"
+                );
+                assert_ne!(
+                    parent_span_context.span_id(),
+                    child_span_context.span_id(),
+                    "each span has its own span ID"
+                );
+
+                tracing::warn!("capture current child context");
+                sentry::capture_message("captured after warning", sentry::Level::Warning);
+
+                expected_trace_id = Some(child_span_context.trace_id().to_string());
+                expected_span_id = Some(child_span_context.span_id().to_string());
+
+                sentry::configure_scope(|scope| {
+                    scope.remove_tag("otel.trace_id");
+                    scope.remove_tag("otel.span_id");
+                });
+            });
+        });
+
+        let event = events.first().expect("one captured Sentry event");
+        assert_eq!(events.len(), 1);
+        assert_eq!(event.tags.get("otel.trace_id"), expected_trace_id.as_ref());
+        assert_eq!(event.tags.get("otel.span_id"), expected_span_id.as_ref());
+    }
+
+    #[test]
+    fn scope_tags_are_attached_to_later_events_until_removed() {
+        let events = sentry::test::with_captured_events(|| {
+            sentry::configure_scope(|scope| {
+                scope.set_tag("otel.trace_id", "first-operation-trace");
+            });
+
+            sentry::capture_message("first event", sentry::Level::Error);
+            sentry::capture_message("later event", sentry::Level::Error);
+
+            sentry::configure_scope(|scope| {
+                scope.remove_tag("otel.trace_id");
+            });
+            sentry::capture_message("event after cleanup", sentry::Level::Error);
+        });
+
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events[0].tags.get("otel.trace_id").map(String::as_str),
+            Some("first-operation-trace")
+        );
+        assert_eq!(
+            events[1].tags.get("otel.trace_id").map(String::as_str),
+            Some("first-operation-trace")
+        );
+        assert!(!events[2].tags.contains_key("otel.trace_id"));
     }
 }

--- a/bookapp/src/sentry_correlation.rs
+++ b/bookapp/src/sentry_correlation.rs
@@ -245,6 +245,33 @@ mod tests {
     }
 
     #[test]
+    fn non_qualifying_event_preserves_existing_correlation_tags() {
+        let subscriber = tracing_subscriber::registry().with(SentryOtelCorrelationLayer::new());
+        let events = sentry::test::with_captured_events(|| {
+            sentry::configure_scope(|scope| {
+                scope.set_tag("otel.trace_id", "existing-trace");
+                scope.set_tag("otel.span_id", "existing-span");
+            });
+
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::info!("event below the correlation threshold");
+            });
+            sentry::capture_message("captured after info", sentry::Level::Info);
+        });
+
+        let event = events.first().expect("one captured Sentry event");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            event.tags.get("otel.trace_id").map(String::as_str),
+            Some("existing-trace")
+        );
+        assert_eq!(
+            event.tags.get("otel.span_id").map(String::as_str),
+            Some("existing-span")
+        );
+    }
+
+    #[test]
     fn error_event_uses_the_current_child_span_context() {
         let provider = SdkTracerProvider::builder().build();
         let subscriber = tracing_subscriber::registry()

--- a/bookapp/src/sentry_correlation.rs
+++ b/bookapp/src/sentry_correlation.rs
@@ -284,11 +284,6 @@ mod tests {
 
                 expected_trace_id = Some(child_span_context.trace_id().to_string());
                 expected_span_id = Some(child_span_context.span_id().to_string());
-
-                sentry::configure_scope(|scope| {
-                    scope.remove_tag("otel.trace_id");
-                    scope.remove_tag("otel.span_id");
-                });
             });
         });
 

--- a/tests/src/telemetry_test.rs
+++ b/tests/src/telemetry_test.rs
@@ -373,7 +373,7 @@ async fn query_tempo_for_trace(
                                         println!("Failed to parse Tempo JSON response: {e:?}");
                                         println!(
                                             "Response text (first 500 chars): {}",
-                                            &response_text.chars().take(500).collect::<String>()
+                                            response_text.chars().take(500).collect::<String>()
                                         );
                                     }
                                 }


### PR DESCRIPTION
## What

- Fix the WARN severity threshold so the correlation layer handles ERROR and WARN events, not INFO through TRACE.
- Add a regression test covering every tracing level.
- Add a nested-span test showing that parent and child spans share a trace ID but have distinct span IDs, and that the current span ID is attached to the captured event.
- Clear stale correlation tags when a qualifying event has no active span or no usable OpenTelemetry context.
- Add scope-lifecycle and missing-context tests documenting safe correlation behavior.
- Correct stale correlation-layer documentation.
- Fix two formatting expressions rejected by current stable Clippy.

## Why

`tracing::Level` is ordered `ERROR < WARN < INFO < DEBUG < TRACE`. The previous `>= WARN` comparison therefore excluded ERROR and included less severe events.

The span test also makes an important distinction explicit: a parent span is normally part of the same trace, so reading parent context can preserve the correct trace ID while producing the wrong span ID. Current main already uses the current `OtelData` trace/span accessors after the OpenTelemetry dependency upgrade.

Sentry scope tags are stateful. The application already creates a new Sentry Hub per HTTP request, but tags can also outlive individual events within one request. Missing-context events therefore clear both correlation tags instead of retaining identifiers from an earlier span.

## Impact

WARN and ERROR events receive the current OpenTelemetry trace and span tags. INFO, DEBUG, and TRACE events skip the correlation work. Qualifying events without usable OpenTelemetry context remove stale correlation tags.

## Checks

- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo test -p bookapp sentry_correlation` (8 passed)
- `RUSTC_WRAPPER= SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTC_WRAPPER= SQLX_OFFLINE=true cargo build --workspace`

The full integration suite additionally requires the repository's PostgreSQL and telemetry services; GitHub Actions provisions them.